### PR TITLE
Implement control flow opcodes

### DIFF
--- a/reference.txt
+++ b/reference.txt
@@ -80,4 +80,20 @@ SECTION: IO Operations
   0x53 puts (s:str) -- Prints a string from the stack.
 
 TODO: Variable Operations
-TODO: Control Flow
+
+SECTION: Control Flow
+  Opcodes for dealing with control flow and instruction pointer manipulation.
+  All opcodes in this section use static label names structured like string literals (0x09) unless otherwise specified.
+  Example:
+    -- Correct
+    labl 4 test
+
+    -- Incorrect
+    str 4 test
+    labl
+= opcd name (params) ==============================================================================================================
+  0x70 labl ()              -- Creates a label which can be jumped to.
+  0x71 jump ()              -- Jumps to the label of the given name.
+  0x72 jmpc (b:bool)        -- Jumps to the label of the given name if b is true.
+  0x73 jmps (s:str)         -- Jumps to the label of the given name. Gets its label name from the stack.
+  0x74 jmsc (s:str, b:bool) -- Jumps to the label of the given name if b is true. Gets its label name from the stack.

--- a/spec/opcode_spec.cr
+++ b/spec/opcode_spec.cr
@@ -68,4 +68,42 @@ describe "SECTION: IO Operations (0x5_)" do
 end
 
 # TODO: Variable Operations
-# TODO: Control Flow
+
+describe "SECTION: Control Flow (0x7_)" do
+  opcode "0x70 labl", [] of SWAny, 0x70, 4.bytes, "test".bytes do
+    result.bytec.labels.should eq({ "test" => 0 })
+  end
+
+  opcode "0x71 jump", ["shown!"],
+    0x71, 4.bytes, "test".bytes,
+    0x09, 7.bytes, "hidden!".bytes,
+    0x70, 4.bytes, "test".bytes,
+    0x09, 6.bytes, "shown!".bytes
+
+  opcode "0x72 jmpc", ["shown!"],
+    0x02, 0x00,
+    0x72, 4.bytes, "test".bytes,
+    0x09, 6.bytes, "shown!".bytes,
+    0x02, 0x01,
+    0x72, 4.bytes, "test".bytes,
+    0x09, 7.bytes, "hidden!".bytes,
+    0x70, 4.bytes, "test".bytes
+
+  opcode "0x73 jmps", ["shown!"],
+    0x09, 4.bytes, "test".bytes,
+    0x73,
+    0x09, 7.bytes, "hidden!".bytes,
+    0x70, 4.bytes, "test".bytes,
+    0x09, 6.bytes, "shown!".bytes
+
+  opcode "0x74 jmsc", ["shown!"],
+    0x02, 0x00,
+    0x09, 4.bytes, "test".bytes,
+    0x74,
+    0x09, 6.bytes, "shown!".bytes,
+    0x02, 0x01,
+    0x09, 4.bytes, "test".bytes,
+    0x74,
+    0x09, 7.bytes, "hidden!".bytes,
+    0x70, 4.bytes, "test".bytes
+end

--- a/spec/spec.cr
+++ b/spec/spec.cr
@@ -7,7 +7,7 @@ macro opcode(name, expected, *bytes, stdin = "", stdout = "", &block)
     it "" do
       withIO(IO::Memory.new(), IO::Memory.new({{stdin}})) {|stdout, stdin|
         result = Sherwood.new(stdin, stdout).runBytecode({{bytes}}.to_a.flatten.map(&.to_u8))
-        result.should eq({{expected}})
+        result.stack.should eq({{expected}})
         stdout.rewind.to_s.should eq({{stdout}})
         {{block && block.body}}
       }

--- a/src/bytecode.cr
+++ b/src/bytecode.cr
@@ -7,14 +7,20 @@ end
 
 class Bytecode < Array(Opcode)
   getter raw
+  getter labels = {} of String => Int32
+
   def initialize(@raw : Array(Byte))
     super()
     insp = 0
 
     while curbyte = @raw[insp]?
-      (size = getCurInstWidth(insp, @raw)) > 0 && 
-        self << Opcode.new(curbyte, @raw[insp+1...insp+size]) || 
-        self << Opcode.new(curbyte)
+      op = (size = getCurInstWidth(insp, @raw)) > 0 ? 
+        Opcode.new(curbyte, @raw[insp+1...insp+size]) :
+        Opcode.new(curbyte)
+      case curbyte
+        when 0x70 then self.labels[op.data.bitwiseString] = self.size
+        else self << op
+      end
       insp += size
     end
   end
@@ -24,7 +30,7 @@ class Bytecode < Array(Opcode)
     when 0x01, 0x02 then 1
     when 0x03, 0x05, 0x07 then 4
     when 0x04, 0x06, 0x08 then 8
-    when 0x09 then 4+prog[insp+1..insp+4].bitwiseConcat
+    when 0x09, 0x70, 0x71, 0x72 then 4+prog[insp+1..insp+4].bitwiseConcat
     when 0x0a then 4
     else 0
     end

--- a/src/sherwood.cr
+++ b/src/sherwood.cr
@@ -138,7 +138,7 @@ class Sherwood
   # Jumps to the location of the given label.
   private macro gotoLabel(insp, prog, name)
     {{insp}} = {{prog}}.labels[{{name}}]?.try(&.-(1)) ||
-      raise "Goto error: Attempted to jump to non-existent label #{{{name}}}"
+      raise "Jump error: Attempted to jump to non-existent label #{{{name}}}"
   end
 end
 

--- a/src/sherwood.cr
+++ b/src/sherwood.cr
@@ -32,7 +32,7 @@ class Sherwood
       when 0x06 then stack.push(op.data.map(&.to_u64).bitwiseConcat)
       when 0x07 then stack.push(Float32.fromBytes(op.data))
       when 0x08 then stack.push(Float64.fromBytes(op.data))
-      when 0x09 then stack.push(op.data.skip(4).map(&.chr).sum(""))
+      when 0x09 then stack.push(op.data.bitwiseString)
       when 0x0a then 
         (size = op.data.map(&.to_u32).bitwiseConcat) > 0 &&
           stack.push(Array(SWAny).new(size) { stack.pop }) ||
@@ -94,7 +94,13 @@ class Sherwood
       when 0x53 then @stdout.print popType(String, stack)
 
       # TODO: Variable Operations
-      # TODO: Control Flow
+
+      # SECTION: Control Flow
+      when 0x70 then # Label (handled at parsetime)
+      when 0x71 then gotoLabel(insp, prog, op.data.bitwiseString)
+      when 0x72 then gotoLabel(insp, prog, op.data.bitwiseString) if popType(Bool, stack)
+      when 0x73 then gotoLabel(insp, prog, popType(String, stack))
+      when 0x74 then s = popType(String, stack); gotoLabel(insp, prog, s) if popType(Bool, stack)
 
       else raise "Encountered undefined opcode 0x#{op.opcd.to_s(16).rjust(2,'0')}"
       end
@@ -127,6 +133,12 @@ class Sherwood
   # Checks the type of the top of the stack and returns true if it matches.
   private macro checkType(typ, stack, pos = -1)
     {{stack}}[{{pos}}].is_a?({{typ}})
+  end
+
+  # Jumps to the location of the given label.
+  private macro gotoLabel(insp, prog, name)
+    {{insp}} = {{prog}}.labels[{{name}}]?.try(&.-(1)) ||
+      raise "Goto error: Attempted to jump to non-existent label #{{{name}}}"
   end
 end
 

--- a/src/sherwood.cr
+++ b/src/sherwood.cr
@@ -103,7 +103,13 @@ class Sherwood
       insp += 1
     end
 
-    return stack
+    return EvalResult.new(stack, prog)
+  end
+
+  struct EvalResult
+    getter stack : Array(Types::SWAny)
+    getter bytec : Bytecode
+    def initialize(@stack, @bytec) end
   end
 
   # Pops a value of the given type from the stack or throws a type error on failure.

--- a/src/util.cr
+++ b/src/util.cr
@@ -2,6 +2,7 @@ alias Byte = UInt8
 
 class Array
   def bitwiseConcat(size = 8); self.reduce {|a,b| (a<<size)+b} end
+  def bitwiseString(lenSize = 4); self.skip(lenSize).map(&.chr).sum("") end
 end
 
 struct Float32


### PR DESCRIPTION
Implements labeled `goto` control flow, via the following 5 opcodes:

- `0x70 labl`: Creates a label which can be jumped to.
- `0x71 jump`: Jumps to the label of the given name.
- `0x72 jmpc`: Jumps to the label of the given name if `b` is `true`.
- `0x73 jmps`: Jumps to the label of the given name. Gets its label name from the stack.
- `0x74 jmsc`: Jumps to the label of the given name if `b` is `true`. Gets its label name from the stack.

Labels are recognized at parse time, converted to entries in a `String => Int32` jump table stored in `Bytecode#labels` (pointing to the following instruction), and removed. The jump opcodes then use that jump table to update the instruction pointer. This could also be implemented by making the `0x70 labl` opcode a no-op at runtime, but for various reasons, including performance, I felt it was better to strip them from the code during parsing.

Attempting to jump to a non-existent label will cause a runtime error: 
```
Jump error: Attempted to jump to non-existent label {name}
```

The language reference and tests have been updated accordingly.